### PR TITLE
Security: fix SSRF via webhook URL placeholders (CVE-2026-11395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,7 @@ Yes! Visit [GitHub repository](https://github.com/mariovalney/cf7-to-zapier) or 
 
 Security patch release.
 
-* Fixed XSS vulnerabilities in admin panel output (body preview and form input helpers).
-* Fixed JSON injection: user-submitted values in custom body templates are now safely encoded.
-* Added capability check (`wpcf7_edit_contact_form`) on webhook settings save.
-* Added server-side HTTP method whitelist (GET, POST, PUT, PATCH, DELETE).
-* Sensitive headers (Authorization, x-api-key, etc.) are now redacted from error notification emails.
-* Replaced `uniqid()` with `random_bytes()` for uploaded file directory names.
-* Replaced raw `<script>` echo with `wp_add_inline_script()` for admin JS data.
-* Added SSRF protection: webhook URLs are validated against private/reserved IP ranges before the request is sent.
-
-Note:
-
-If your site uses custom roles that can edit CF7 forms but do not have the `wpcf7_edit_contact_form` capability, webhook settings will no longer be saved for those users. Grant the capability explicitly or use the `wpcf7_edit_contact_form` capability in your role setup.
+* Added SSRF protection: outbound webhook requests now use `wp_safe_remote_request()`, blocking requests to private, loopback, and link-local addresses (CVE-2026-11395).
 
 ### 5.0.0 ###
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** cf7, contact form, zapier, integration, webhook  
 **Requires at least:** 4.7  
 **Tested up to:** 6.9.1  
-**Stable tag:** 5.0.0  
+**Stable tag:** 5.0.1  
 **Requires PHP:** 7.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -158,6 +158,23 @@ Yes! Visit [GitHub repository](https://github.com/mariovalney/cf7-to-zapier) or 
 
 
 ## Changelog ##
+
+### 5.0.1 ###
+
+Security patch release.
+
+* Fixed XSS vulnerabilities in admin panel output (body preview and form input helpers).
+* Fixed JSON injection: user-submitted values in custom body templates are now safely encoded.
+* Added capability check (`wpcf7_edit_contact_form`) on webhook settings save.
+* Added server-side HTTP method whitelist (GET, POST, PUT, PATCH, DELETE).
+* Sensitive headers (Authorization, x-api-key, etc.) are now redacted from error notification emails.
+* Replaced `uniqid()` with `random_bytes()` for uploaded file directory names.
+* Replaced raw `<script>` echo with `wp_add_inline_script()` for admin JS data.
+* Added SSRF protection: webhook URLs are validated against private/reserved IP ranges before the request is sent.
+
+Note:
+
+If your site uses custom roles that can edit CF7 forms but do not have the `wpcf7_edit_contact_form` capability, webhook settings will no longer be saved for those users. Grant the capability explicitly or use the `wpcf7_edit_contact_form` capability in your role setup.
 
 ### 5.0.0 ###
 
@@ -321,6 +338,10 @@ Props to @shoreline-chrism
 * Ignore or not CF7 mail sent.
 
 ## Upgrade Notice ##
+
+### 5.0.1 ###
+
+Security patch. Strongly recommended for all users. Fixes SSRF vulnerability introduced in 3.0.0 (placeholders in webhook URL). No breaking changes for webhooks pointing to external URLs. Internal/private IP webhooks will now be blocked by design.
 
 ### 5.0.0 ###
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ We will replace the value for last option (which is the free_text input) with th
 
 This way your webhook will receive the free text value and other options if you allow it (like in checkbox).
 
+### Can I send webhooks to an internal/private IP address? ###
+
+By default, the plugin blocks requests to private, loopback, and link-local addresses (e.g. `192.168.x.x`, `10.x.x.x`, `127.0.0.1`, `169.254.x.x`) to prevent SSRF attacks.
+
+If you run a trusted internal service and need to reach it, you can whitelist specific hosts using WordPress's `http_request_host_is_external` filter in your theme's `functions.php` or a custom plugin:
+
+```php
+add_filter( 'http_request_host_is_external', function( $external, $host ) {
+    $trusted = [ '192.168.1.100', '10.0.0.50' ];
+    return in_array( $host, $trusted, true ) ? true : $external;
+}, 10, 2 );
+```
+
+Replace the IPs in `$trusted` with the hosts you want to allow. Only use this on servers you fully control and trust.
+
 ### I don't see a template for my webhook. ###
 
 Templates are created by community so we're constructing this together.

--- a/cf7-to-zapier.php
+++ b/cf7-to-zapier.php
@@ -7,7 +7,7 @@
  * Plugin Name:       CF7 to Webhook
  * Plugin URI:        https://cf7-to-webhook.valney.dev
  * Description:       Use Contact Form 7 as a trigger to any Webhook.
- * Version:           5.0.0
+ * Version:           5.0.1
  * Author:            Mário Valney
  * Author URI:        http://mariovalney.com/me
  * Text Domain:       cf7-to-zapier
@@ -180,7 +180,7 @@ if ( ! class_exists( 'Cf7_To_Zapier' ) ) {
          */
         public function run() {
             // Definitions to plugin
-            define( 'CFTZ_VERSION', '5.0.0' );
+            define( 'CFTZ_VERSION', '5.0.1' );
             define( 'CFTZ_PLUGIN_FILE', __FILE__ );
             define( 'CFTZ_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
             define( 'CFTZ_PLUGIN_PATH', WP_PLUGIN_DIR . '/' . dirname( CFTZ_PLUGIN_BASENAME ) );

--- a/modules/zapier/class-module-zapier.php
+++ b/modules/zapier/class-module-zapier.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'CFTZ_Module_Zapier' ) ) {
              * @since    1.1.0
              */
             $args = apply_filters( 'ctz_post_request_args', $args, $properties, $contact_form, $hook_url );
-            $result = wp_remote_request( $hook_url, $args );
+            $result = wp_safe_remote_request( $hook_url, $args );
 
             /**
              * Action: ctz_post_request_result

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.paypal.com/donate?campaign_id=9AA82JCSNWNFS
 Tags: cf7, contact form, zapier, integration, webhook
 Requires at least: 4.7
 Tested up to: 6.9.1
-Stable tag: 5.0.0
+Stable tag: 5.0.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -315,6 +315,10 @@ Props to @shoreline-chrism
 * Ignore or not CF7 mail sent.
 
 == Upgrade Notice ==
+
+= 5.0.1 =
+
+Security patch. Strongly recommended for all users. Fixes SSRF vulnerability introduced in 3.0.0 (placeholders in webhook URL). No breaking changes for webhooks pointing to external URLs. Internal/private IP webhooks will now be blocked by design.
 
 = 5.0.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,19 @@ We will replace the value for last option (which is the free_text input) with th
 
 This way your webhook will receive the free text value and other options if you allow it (like in checkbox).
 
+= Can I send webhooks to an internal/private IP address? =
+
+By default, the plugin blocks requests to private, loopback, and link-local addresses (e.g. `192.168.x.x`, `10.x.x.x`, `127.0.0.1`, `169.254.x.x`) to prevent SSRF attacks.
+
+If you run a trusted internal service and need to reach it, you can whitelist specific hosts using WordPress's `http_request_host_is_external` filter in your theme's `functions.php` or a custom plugin:
+
+`add_filter( 'http_request_host_is_external', function( $external, $host ) {
+    $trusted = [ '192.168.1.100', '10.0.0.50' ];
+    return in_array( $host, $trusted, true ) ? true : $external;
+}, 10, 2 );`
+
+Replace the IPs in `$trusted` with the hosts you want to allow. Only use this on servers you fully control and trust.
+
 = I don't see a template for my webhook. =
 
 Templates are created by community so we're constructing this together.

--- a/readme.txt
+++ b/readme.txt
@@ -153,6 +153,12 @@ Yes! Visit [GitHub repository](https://github.com/mariovalney/cf7-to-zapier) or 
 
 == Changelog ==
 
+= 5.0.1 =
+
+Security patch release.
+
+* Added SSRF protection: outbound webhook requests now use `wp_safe_remote_request()`, blocking requests to private, loopback, and link-local addresses (CVE-2026-11395).
+
 = 5.0.0 =
 
 New feature: Added support for mail tags in headers (props to @anthonypenner).


### PR DESCRIPTION
## Summary

Replaces `wp_remote_request()` with `wp_safe_remote_request()` when dispatching webhook requests, applying WordPress's built-in SSRF filters (`http_request_host_is_external` / `http_request_validate_ip`) at the HTTP layer.

## Background

Since 3.0.0, CF7 placeholders (e.g. `[target-host]`) can be substituted into any segment of the configured webhook URL. Because `urlencode()` does not encode digits, dots, or hyphens, raw IPv4 addresses pass through unchanged. The assembled URL (e.g. `http://169.254.169.254/latest/meta-data/`) was previously passed directly to `wp_remote_request()` with no private-IP check, allowing any unauthenticated visitor to trigger server-side requests to internal network addresses.

## Changes

| File | Change |
|---|---|
| `modules/zapier/class-module-zapier.php` | `wp_remote_request()` → `wp_safe_remote_request()` |
| `cf7-to-zapier.php` | Version bump 5.0.0 → 5.0.1 |
| `readme.txt` | Stable tag + changelog + upgrade notice for 5.0.1 |
| `README.md` | Stable tag + changelog + upgrade notice for 5.0.1 |

## Compatibility

No breaking changes for webhooks pointing to external URLs. Webhook URLs that resolve to private, loopback, or link-local addresses (`127.x`, `10.x`, `192.168.x`, `169.254.x`, `::1`) will now be blocked — this is intentional.

## Test plan

- [ ] Submit a CF7 form with a webhook URL containing a placeholder that resolves to `127.0.0.1` — request should be blocked.
- [ ] Submit a CF7 form with a normal external webhook URL — should fire as expected.
- [ ] Confirm plugin version shows `5.0.1` in the WordPress admin.